### PR TITLE
WFS Orders Canada

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,6 +40,10 @@ fn main() {
         (about: "Get orders created in last 24 hours")
         (@arg STATUS: "Sets the order status (default: Created)")        
       )
+      (@subcommand list_wfs =>
+        (about: "Get WFS orders created in last 24 hours")
+        (@arg STATUS: "Sets the order status (default: Created)")
+      )
       (@subcommand list_released => 
       )
       (@subcommand list_status =>
@@ -156,6 +160,9 @@ fn main() {
     ("order", Some(matches)) => match matches.subcommand() {
       ("list", m) => {
         order::list(&client, m.and_then(|m| m.value_of("STATUS")));
+      }
+      ("list_wfs", m) => {
+        order::list_wfs(&client, m.and_then(|m| m.value_of("STATUS")));
       }
       ("list_released", _) => {
         order::list_released(&client);

--- a/cli/src/order.rs
+++ b/cli/src/order.rs
@@ -18,9 +18,7 @@ pub fn list_wfs(client: &Client, status: Option<&str>) {
   let mut query: WFSQueryParams = Default::default();
   let start_date = (Utc::now() - Duration::days(7));
   query.createdStartDate = Some(start_date);
-  query.createdEndDate = Some(Utc::now());
-  // query.status = status.or(Some("Created")).map(|s| s.to_owned());
-  // query.status = status.or(Some("Acknowledged")).map(|s| s.to_owned());
+  query.status = status.map(|s| s.to_owned());
   let res = client.get_all_wfs_orders(&query).unwrap();
   println!("{:#?}", res);
 }

--- a/cli/src/order.rs
+++ b/cli/src/order.rs
@@ -14,6 +14,17 @@ pub fn list(client: &Client, status: Option<&str>) {
   println!("{:#?}", res);
 }
 
+pub fn list_wfs(client: &Client, status: Option<&str>) {
+  let mut query: WFSQueryParams = Default::default();
+  let start_date = (Utc::now() - Duration::days(7));
+  query.createdStartDate = Some(start_date);
+  query.createdEndDate = Some(Utc::now());
+  // query.status = status.or(Some("Created")).map(|s| s.to_owned());
+  // query.status = status.or(Some("Acknowledged")).map(|s| s.to_owned());
+  let res = client.get_all_wfs_orders(&query).unwrap();
+  println!("{:#?}", res);
+}
+
 pub fn list_released(client: &Client) {
   let query: ReleasedQueryParams = Default::default();
   let res = client.get_all_released_orders(&query).unwrap();
@@ -82,7 +93,10 @@ pub fn ship(client: &Client, m: &ArgMatches) {
     otherCarrier: m.value_of("other_carrier").map(ToString::to_string),
     unitOfMeasurement: m.value_of("unit_of_measurement").map(ToString::to_string),
     amount: m.value_of("amount").map(ToString::to_string),
-    shipFromCountry: m.value_of("shipFromCountry").map(ToString::to_string).unwrap(),
+    shipFromCountry: m
+      .value_of("shipFromCountry")
+      .map(ToString::to_string)
+      .unwrap(),
   };
   let res = client
     .ship_order_line(m.value_of("ORDER_ID").unwrap(), &params)

--- a/walmart-partner-api/Cargo.toml
+++ b/walmart-partner-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walmart_partner_api"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Flux Xu <fluxxu@gmail.com>"]
 description = "Rust client for Walmart Partner APIs"
 repository = "https://github.com/Ventmere/walmart-partner-api"

--- a/walmart-partner-api/src/order/mod.rs
+++ b/walmart-partner-api/src/order/mod.rs
@@ -36,6 +36,16 @@ pub struct QueryParams {
   pub shipNodeType: Option<String>,
 }
 
+#[derive(Debug, Serialize, Default)]
+pub struct WFSQueryParams {
+  pub customerOrderId: Option<String>,
+  pub createdStartDate: Option<DateTime<Utc>>,
+  pub createdEndDate: Option<DateTime<Utc>>,
+  pub status: Option<String>,
+  pub limit: Option<i32>,
+  pub offset: Option<i32>,
+}
+
 #[derive(Debug, Clone)]
 #[allow(non_snake_case)]
 pub struct ShipParams {
@@ -84,6 +94,7 @@ impl ShipParams {
 }
 
 pub type OrderList = ListResponse<Order>;
+pub type OrderWFSList = ListResponse<OrderWFS>;
 
 impl Client {
   pub fn get_all_released_orders(&self, params: &ReleasedQueryParams) -> WalmartResult<OrderList> {
@@ -96,6 +107,16 @@ impl Client {
     let mut res = self.send(self.request_json(
       Method::GET,
       "/v3/orders",
+      serde_urlencoded::to_string(params)?,
+    )?)?;
+    parse_list_elements_json(res.status(), &mut res, "order").map_err(Into::into)
+  }
+
+  /// Get all WFS orders (Only Canada)
+  pub fn get_all_wfs_orders(&self, params: &WFSQueryParams) -> WalmartResult<OrderWFSList> {
+    let mut res = self.send(self.request_json(
+      Method::GET,
+      "/v3/orders/wfs",
       serde_urlencoded::to_string(params)?,
     )?)?;
     parse_list_elements_json(res.status(), &mut res, "order").map_err(Into::into)

--- a/walmart-partner-api/src/order/types.rs
+++ b/walmart-partner-api/src/order/types.rs
@@ -125,6 +125,17 @@ pub struct Order {
   pub orderLines: OrderLines,
 }
 
+// We need a separate WFS type because CA API doesn't return `purchaseOrderId` field for WFS orders
+#[derive(Debug, Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct OrderWFS {
+  pub customerOrderId: String,
+  pub customerEmailId: Option<String>,
+  pub orderDate: i64,
+  pub shippingInfo: ShippingInformation,
+  pub orderLines: OrderLines,
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;


### PR DESCRIPTION
* Add `get_all_wfs_orders` to list WFS orders (supported only in Canada)
* Bumped version to `0.7.0`
* CLI command: `cargo run --bin cli order list_wfs`