### PR TITLE
CA Order List - Fix get by next cursor

### DIFF
--- a/cli/src/order.rs
+++ b/cli/src/order.rs
@@ -49,6 +49,7 @@ pub fn dump(client: &Client) {
   let mut next_cursor = res.get_next_cursor().map(str::to_string);
   let mut elements = res.elements;
   while let Some(cursor) = next_cursor {
+    println!("next_cursor = {:?}", cursor);
     let mut res = client.get_all_orders_by_next_cursor(&cursor).unwrap();
     next_cursor = res.get_next_cursor().map(str::to_string);
     // println!(

--- a/walmart-partner-api/Cargo.toml
+++ b/walmart-partner-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walmart_partner_api"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Flux Xu <fluxxu@gmail.com>"]
 description = "Rust client for Walmart Partner APIs"
 repository = "https://github.com/Ventmere/walmart-partner-api"

--- a/walmart-partner-api/Cargo.toml
+++ b/walmart-partner-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "walmart_partner_api"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Flux Xu <fluxxu@gmail.com>"]
 description = "Rust client for Walmart Partner APIs"
 repository = "https://github.com/Ventmere/walmart-partner-api"

--- a/walmart-partner-api/src/order/mod.rs
+++ b/walmart-partner-api/src/order/mod.rs
@@ -128,7 +128,7 @@ impl Client {
       self.request_json(
         Method::GET,
         "/v3/orders",
-        form_urlencoded::parse((&next_cursor[1..]).as_bytes())
+        form_urlencoded::parse((&next_cursor).as_bytes())
           .into_owned()
           .collect::<Vec<_>>(),
       )?,

--- a/walmart-partner-api/src/order/types.rs
+++ b/walmart-partner-api/src/order/types.rs
@@ -22,7 +22,7 @@ pub struct PostalAddress {
 #[allow(non_snake_case)]
 pub struct ShippingInformation {
   pub phone: Option<String>,
-  pub estimatedDeliveryDate: i64,
+  pub estimatedDeliveryDate: Option<i64>,
   pub estimatedShipDate: i64,
   pub methodCode: String,
   pub postalAddress: PostalAddress,


### PR DESCRIPTION
## In this PR
* Made `estimatedDeliveryDate` optional
* Fixed the `nextCursor` slicing issue in Walmart order sync.
* The CA cursor doesn’t start with `?` like the US cursor does, so we used to skip the first character for the US.
* Ensured it works for both US and CA
Example CA cursor: `createdStartDate=2024-06-06T00:00:00Z&limit=200&poIndex=200`